### PR TITLE
Support global installation via npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,19 @@ Handy if you want to verify if your metrics are what you expect them to be.
 
 NOTE: this is by no means a full-fledged statsd aggregator.
 
-# run
-npm start
+## Install
+You can install globally for convenience, which will add a `statsd-daemon` executable to your path:
+```
+$ npm install -g @q42philips/statsd-daemon
+```
+
+# Run
+If installed globally:
+```
+$ statsd-daemon
+```
+
+Otherwise in this directory:
+```
+$ npm start
+```

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "test": "npm run lint",
     "lint": "eslint . --max-warnings 0 --ignore-path .eslintignore"
   },
+  "bin": {
+    "statsd-daemon": "src/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Q42Philips/statsd-daemon.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "statsd-daemon",
-  "version": "1.0.0",
+  "name": "@q42philips/statsd-daemon",
+  "version": "0.0.0",
   "description": "Simple statsd deamon to observe metrics being emitted on localhost",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+#! /usr/bin/env node
 const dgram = require('dgram');
 const server = dgram.createSocket('udp4');
 


### PR DESCRIPTION
- Renames the app to `@q42philips/statsd-daemon` to work with NPM
- Set version to `0.0.0` in order to be able to release `1.0.0`
- Adds a binary to support global installation